### PR TITLE
Save spans and scopes in a stack

### DIFF
--- a/src/OpenTelemetry.php
+++ b/src/OpenTelemetry.php
@@ -11,41 +11,60 @@ use OpenTelemetry\Context\ScopeInterface;
 
 class OpenTelemetry
 {
-    private SpanInterface $span;
-    private ScopeInterface $scope;
-    public function getTracer(): TracerInterface|null{
+    private array $span;
+    private array $scope;
+    public function getTracer(): ?TracerInterface {
         return Config::get("tracer");
     }
 
-    public function startSpan(string $spanName, array $attributes = [], $spanKind = SpanKind::KIND_CONSUMER){
+    public function startSpan(string $spanName, array $attributes = [], ?int $start = null, $spanKind = SpanKind::KIND_CONSUMER){
         $tracer = $this->getTracer();
         if ($tracer) {
-            $this->span = $tracer->spanBuilder($spanName)->setSpanKind($spanKind)->startSpan();
-            $this->span->setAttributes($attributes);
-            $this->scope = $this->span->activate();
+            $builder = $tracer
+                ->spanBuilder($spanName)
+                ->setSpanKind($spanKind);
+
+            if ($start) {
+                $builder = $builder->setStartTimestamp($start);
+            }
+            $span = $builder
+                ->startSpan();
+
+            $span->setAttributes($attributes);
+            $this->scope[] = $span->activate();
+            $this->span[] = $span;
         }
 
         return $this;
     }
 
     public function setAttribute($key, $value){
-        $this->span->setAttribute($key, $value);
+        $this->getLastSpan()->setAttribute($key, $value);
         return $this;
     }
 
     public function setSpanStatusCode(string $statusCode = StatusCode::STATUS_OK){
-        $this->span->setStatus($statusCode, true);
+        $this->getLastSpan()->setStatus($statusCode, true);
         return $this;
     }
 
     public function recordException(\Throwable $exception){
-        $this->span->recordException($exception, $exception->getTrace());
+        $this->getLastSpan()->recordException($exception, $exception->getTrace());
         return $this;
     }
 
-    public function endSpan(){
-        $this->span->end();
-        $this->scope->detach();
+    public function endSpan($end = null){
+        $span = array_pop($this->span);
+        $scope = array_pop($this->scope);
+        if ($span) {
+            $span->end($end);
+            $scope->detach();
+        }
         return $this;
+    }
+
+    private function getLastSpan(): SpanInterface
+    {
+        return $this->span[count($this->span) - 1];
     }
 }


### PR DESCRIPTION
Usage will fail if the stack is empty when calling setters. Improvements needed.