### PR TITLE
Add message sent listener

### DIFF
--- a/src/Listeners/MessageSentListener.php
+++ b/src/Listeners/MessageSentListener.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tavsec\LaravelOpentelemetry\Listeners;
+
+use Illuminate\Mail\Events\MessageSent;
+use OpenTelemetry\API\Trace\SpanKind;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Part\DataPart;
+use Tavsec\LaravelOpentelemetry\OpenTelemetry;
+
+class MessageSentListener
+{
+    public function handle(MessageSent $event){
+        $end = now();
+        $start = $end->copy()->sub((float) $event->message->getDate(), 'milliseconds');
+        $tracing = (new OpenTelemetry)->startSpan("message-sent " . $event->message->getSubject(), [
+            "laravel.message.from" => json_encode(collect($event->message->getFrom())->map(fn(Address $el) => $el->getAddress())),
+            "laravel.message.to" => json_encode(collect($event->message->getTo())->map(fn(Address $el) => $el->getAddress())),
+            "laravel.message.bcc" => json_encode(collect($event->message->getBcc())->map(fn(Address $el) => $el->getAddress())),
+            "laravel.message.cc" => json_encode(collect($event->message->getCc())->map(fn(Address $el) => $el->getAddress())),
+            "laravel.message.message" => $event->message->getBody()->bodyToString(),
+            "laravel.message.subject" => $event->message->getSubject(),
+            "laravel.message.priority" => $event->message->getPriority(),
+        ], (int) $start->getPreciseTimestamp() * 1_000, SpanKind::KIND_CLIENT);
+
+        $tracing->endSpan((int) $end->getPreciseTimestamp() * 1_000);
+    }
+}

--- a/src/OpenTelemetry.php
+++ b/src/OpenTelemetry.php
@@ -133,7 +133,9 @@ class OpenTelemetry
      */
     private function processAttributes(array $attributes)
     {
-        return collect($attributes)->mapWithKeys(fn($el, $key) => [$key =>  Str::limit($el, config("opentelemetry.attribute_length_limit"), "")])->toArray();
+        return collect($attributes)->mapWithKeys(fn($el, $key) =>
+            [$key =>  Str::limit(is_string($el) ? $el : json_encode($el), config("opentelemetry.attribute_length_limit", 4095), "")]
+        )->toArray();
     }
 
     public static function maskValue($key, $value){

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -10,8 +10,10 @@ use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Http\Client\Events\RequestSending;
 use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Mail\Events\MessageSent;
 use Tavsec\LaravelOpentelemetry\Listeners\CacheHitListener;
 use Tavsec\LaravelOpentelemetry\Listeners\CacheMissedListener;
+use Tavsec\LaravelOpentelemetry\Listeners\MessageSentListener;
 use Tavsec\LaravelOpentelemetry\Listeners\QueryExecutedListener;
 use Tavsec\LaravelOpentelemetry\Listeners\RequestSendingListener;
 use Tavsec\LaravelOpentelemetry\Listeners\ResponseReceivedListener;
@@ -24,7 +26,8 @@ class EventServiceProvider extends ServiceProvider
         CacheHit::class => [CacheHitListener::class],
         CacheMissed::class => [CacheMissedListener::class],
         ResponseReceived::class => [ResponseReceivedListener::class],
-        ScheduledTaskFinished::class => [ScheduledTaskFinishedListener::class]
+        ScheduledTaskFinished::class => [ScheduledTaskFinishedListener::class],
+        MessageSent::class => [MessageSentListener::class]
     ];
 
     public function boot()


### PR DESCRIPTION
Added event listener for `MessageSent`, which creates new span when message is sent from application. The following attributes are added to the span:
```php
"laravel.message.from",
"laravel.message.to",
"laravel.message.bcc",
"laravel.message.cc",
"laravel.message.message",
"laravel.message.subject",
"laravel.message.priority",
```

<img width="1440" alt="image" src="https://github.com/tavsec/laravel-opentelemetry/assets/31708774/a61e7cd1-bc84-45b6-bcb5-1651ae4b9f73">
